### PR TITLE
Add public methods to access sql scripts

### DIFF
--- a/cipherstash-pg.gemspec
+++ b/cipherstash-pg.gemspec
@@ -5,7 +5,7 @@ require_relative 'lib/pg/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "cipherstash-pg"
-  spec.version       = PG::VERSION
+  spec.version       = PG::VERSION # Match the gem's version intentionally.
   spec.authors       = ["Michael Granger", "Lars Kanis"]
   spec.email         = ["ged@FaerieMUD.org", "lars@greiz-reinsdorf.de"]
 
@@ -25,6 +25,9 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features|vendor)/}) }
   end
+  spec.files << "vendor/driver/database-extensions/postgresql/install.sql"
+  spec.files << "vendor/driver/database-extensions/postgresql/uninstall.sql"
+
   # spec.extensions    = ["ext/extconf.rb"]
   spec.require_paths = ["lib"]
   spec.cert_chain    = ["certs/ged.pem"]

--- a/lib/cipherstash-pg.rb
+++ b/lib/cipherstash-pg.rb
@@ -1,0 +1,15 @@
+require_relative './pg'
+
+module CipherStash
+  module PG
+    DB_EXT_DIR = File.join(__dir__, '../vendor/driver/database-extensions/postgresql')
+
+    def self.install_script
+      File.read(File.join(DB_EXT_DIR, "install.sql"))
+    end
+
+    def self.uninstall_script
+      File.read(File.join(DB_EXT_DIR, "uninstall.sql"))
+    end
+  end
+end


### PR DESCRIPTION
Adds in the public methods to access the sql scripts in the vendor/driver folder.

Testing details done in this other PR. https://github.com/cipherstash/activerecord-cipherstash-pg-adapter/pull/2

This PR is branched off the existing cipherstash-driver branch.





