### PR TITLE
Switch between so.5 and dylib on Linux and macOS

### DIFF
--- a/.github/workflows/source-gem.yml
+++ b/.github/workflows/source-gem.yml
@@ -14,7 +14,7 @@ jobs:
           ruby-version: "3.1"
 
       - name: Build source gem
-        run: gem build pg.gemspec
+        run: gem build cipherstash-pg.gemspec
 
       - name: Upload source gem
         uses: actions/upload-artifact@v2

--- a/cipherstash-pg.gemspec
+++ b/cipherstash-pg.gemspec
@@ -23,7 +23,15 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }.concat(["lib/libpq.so.5"])
+    host_os = RbConfig::CONFIG['host_os'].downcase
+    lib_suffix = if host_os.match? /linux/
+      'so.5'
+    elsif host_os.match? /darwin/
+      'dylib'
+    else
+      fail "unsupported platform: #{host_os}"
+    end
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }.concat(["lib/libpq.#{lib_suffix}"])
   end
   spec.extensions    = ["ext/extconf.rb"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This allows switching between `.so.5` and `.dylib` depending on whether the platform is Linux or Darwin for building the gem on macOS